### PR TITLE
usersテーブル削除＋エラー処理リファクタリング

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -14,5 +14,5 @@
 
  // Custom bootstrap variables must be set or imported *before* bootstrap.
 @import "bootstrap";
-
+@import "./common";
 

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -1,0 +1,5 @@
+.field_with_errors {
+  input {
+    @extend .is-invalid;
+  }
+}

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -8,7 +8,7 @@ class UsersController < ApplicationController
     @user = User.new(user_params)
     if @user.valid?
       begin
-        calculate_time(@user.id, @user.password)
+        calculate_time(@user.login, @user.password)
       rescue
         @error_msg = '惜しい！勤之助のログインに失敗しました！ もう一度お試し下さい。'
       end
@@ -21,6 +21,6 @@ class UsersController < ApplicationController
 
   private
     def user_params
-      params.require(:user).permit(:id, :password)
+      params.require(:user).permit(:login, :password)
     end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,8 +2,8 @@ class User
   #DBを使わない為
   include ActiveModel::Model
 
-  attr_accessor :id, :password, :message
+  attr_accessor :id, :password
 
-  validates :id, :presence => {:message => 'ユーザidを入力してください'}
-  validates :password, :presence => {:message => 'パスワードを入力してください'}
+  validates :id, presence: true
+  validates :password, presence: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,8 +2,8 @@ class User
   #DBを使わない為
   include ActiveModel::Model
 
-  attr_accessor :id, :password
+  attr_accessor :login, :password
 
-  validates :id, presence: true
+  validates :login, presence: true
   validates :password, presence: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,4 @@
-class User < ApplicationRecord
+class User
   #DBを使わない為
   include ActiveModel::Model
 

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,12 +1,11 @@
 <% if @user.errors.any? %>
   <div id="error_explanation">
     <div class="alert alert-danger">
-      The form contains <%= pluralize(@user.errors.count,"error") %>
+      <ul class="mb-0">
+        <% @user.errors.full_messages.each do |msg| %>
+        <li><%= msg %></li>
+        <% end %>
+      </ul>
     </div>
-    <ul>
-      <% @user.errors.full_messages.each do |msg| %>
-      <li><%= msg %></li>
-      <% end %>
-    </ul>
   </div>
 <% end %>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -1,10 +1,10 @@
 <%= form_for @user, :url => {:action => 'check'}  do |f| %>
     <%= render 'shared/error_messages', object: @user %>
 
-    <%= f.label :id, "ログインID" %>
-    <%= f.text_field :id, class: "form-control" %>
+    <%= f.label :login %>
+    <%= f.text_field :login, class: "form-control" %>
 
-    <%= f.label :password, "パスワード" %>
+    <%= f.label :password %>
     <%= f.password_field :password, class: "form-control" %>
 
     <%= f.submit "勤怠時間を確認する。", class: "btn btn-primary" %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -2,7 +2,7 @@
 <div class="container">
   <div class="col-md-8 col-md-offset-3">
       <h1>FlexTimeCheck</h1>
-      <p>勤之助のログインIDとパスワードを入力してください。</p>
+      <p>勤之助の<%= User.human_attribute_name(:login) -%>と<%= User.human_attribute_name(:password) -%>を入力してください。</p>
       <%= render 'form' %>
       <%= render 'login_result' %>
       <%= render 'footer' %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -14,5 +14,6 @@ module FlexTimeCheck
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
+    config.i18n.default_locale = :ja
   end
 end

--- a/config/locales/active_model.ja.yml
+++ b/config/locales/active_model.ja.yml
@@ -1,0 +1,6 @@
+ja:
+  activemodel:
+    attributes:
+      user:
+        id: ユーザid
+        password: パスワード

--- a/config/locales/active_model.ja.yml
+++ b/config/locales/active_model.ja.yml
@@ -2,5 +2,5 @@ ja:
   activemodel:
     attributes:
       user:
-        id: ユーザid
+        login: ログインID
         password: パスワード

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,207 @@
+---
+ja:
+  activerecord:
+    errors:
+      messages:
+        record_invalid: "バリデーションに失敗しました: %{errors}"
+        restrict_dependent_destroy:
+          has_one: "%{record}が存在しているので削除できません"
+          has_many: "%{record}が存在しているので削除できません"
+  date:
+    abbr_day_names:
+    - 日
+    - 月
+    - 火
+    - 水
+    - 木
+    - 金
+    - 土
+    abbr_month_names:
+    -
+    - 1月
+    - 2月
+    - 3月
+    - 4月
+    - 5月
+    - 6月
+    - 7月
+    - 8月
+    - 9月
+    - 10月
+    - 11月
+    - 12月
+    day_names:
+    - 日曜日
+    - 月曜日
+    - 火曜日
+    - 水曜日
+    - 木曜日
+    - 金曜日
+    - 土曜日
+    formats:
+      default: "%Y/%m/%d"
+      long: "%Y年%m月%d日(%a)"
+      short: "%m/%d"
+    month_names:
+    -
+    - 1月
+    - 2月
+    - 3月
+    - 4月
+    - 5月
+    - 6月
+    - 7月
+    - 8月
+    - 9月
+    - 10月
+    - 11月
+    - 12月
+    order:
+    - :year
+    - :month
+    - :day
+  datetime:
+    distance_in_words:
+      about_x_hours:
+        one: 約1時間
+        other: 約%{count}時間
+      about_x_months:
+        one: 約1ヶ月
+        other: 約%{count}ヶ月
+      about_x_years:
+        one: 約1年
+        other: 約%{count}年
+      almost_x_years:
+        one: 1年弱
+        other: "%{count}年弱"
+      half_a_minute: 30秒前後
+      less_than_x_minutes:
+        one: 1分以内
+        other: "%{count}分未満"
+      less_than_x_seconds:
+        one: 1秒以内
+        other: "%{count}秒未満"
+      over_x_years:
+        one: 1年以上
+        other: "%{count}年以上"
+      x_days:
+        one: 1日
+        other: "%{count}日"
+      x_minutes:
+        one: 1分
+        other: "%{count}分"
+      x_months:
+        one: 1ヶ月
+        other: "%{count}ヶ月"
+      x_years:
+        one: 1年
+        other: "%{count}年"
+      x_seconds:
+        one: 1秒
+        other: "%{count}秒"
+    prompts:
+      day: 日
+      hour: 時
+      minute: 分
+      month: 月
+      second: 秒
+      year: 年
+  errors:
+    format: "%{attribute}%{message}"
+    messages:
+      accepted: を受諾してください
+      blank: を入力してください
+      present: は入力しないでください
+      confirmation: と%{attribute}の入力が一致しません
+      empty: を入力してください
+      equal_to: は%{count}にしてください
+      even: は偶数にしてください
+      exclusion: は予約されています
+      greater_than: は%{count}より大きい値にしてください
+      greater_than_or_equal_to: は%{count}以上の値にしてください
+      inclusion: は一覧にありません
+      invalid: は不正な値です
+      less_than: は%{count}より小さい値にしてください
+      less_than_or_equal_to: は%{count}以下の値にしてください
+      model_invalid: "バリデーションに失敗しました: %{errors}"
+      not_a_number: は数値で入力してください
+      not_an_integer: は整数で入力してください
+      odd: は奇数にしてください
+      required: を入力してください
+      taken: はすでに存在します
+      too_long: は%{count}文字以内で入力してください
+      too_short: は%{count}文字以上で入力してください
+      wrong_length: は%{count}文字で入力してください
+      other_than: は%{count}以外の値にしてください
+    template:
+      body: 次の項目を確認してください
+      header:
+        one: "%{model}にエラーが発生しました"
+        other: "%{model}に%{count}個のエラーが発生しました"
+  helpers:
+    select:
+      prompt: 選択してください
+    submit:
+      create: 登録する
+      submit: 保存する
+      update: 更新する
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%n%u"
+        precision: 0
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: 円
+    format:
+      delimiter: ","
+      precision: 3
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: 十億
+          million: 百万
+          quadrillion: 千兆
+          thousand: 千
+          trillion: 兆
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n%u"
+        units:
+          byte: バイト
+          gb: GB
+          kb: KB
+          mb: MB
+          tb: TB
+          pb: PB
+          eb: EB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''
+  support:
+    array:
+      last_word_connector: 、
+      two_words_connector: 、
+      words_connector: 、
+  time:
+    am: 午前
+    formats:
+      default: "%Y年%m月%d日(%a) %H時%M分%S秒 %z"
+      long: "%Y/%m/%d %H:%M"
+      short: "%m/%d %H:%M"
+    pm: 午後

--- a/db/migrate/20180922030513_drop_users.rb
+++ b/db/migrate/20180922030513_drop_users.rb
@@ -1,0 +1,6 @@
+require_relative '20180228205537_create_users'
+class DropUsers < ActiveRecord::Migration[5.1]
+  def change
+    revert CreateUsers
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,6 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180228205537) do
-
-  create_table "users", force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-  end
+ActiveRecord::Schema.define(version: 20180922030513) do
 
 end


### PR DESCRIPTION
## 概要

朝暇でやってしまったのでプルリク出します！
機能改善的な事はなしのほぼリファクタリング。

- usersテーブルを削除して動作する様にコード修正
- エラー処理をリファクタリング
- 列名を日本語化ファイルに集約
- ログインIDの要素名の `id` を `login` に修正（ActiveRecordに移す時対策）

## レビューポイント

・Userクラスはそのまま据え置き。（Kinnoske::Userとかでlib配下に移すと良いのかな・・・）
・`ja.yml` は `https://raw.githubusercontent.com/svenfuchs/rails-i18n/master/rails/locale/ja.yml` から取得して変更なし。
・野生のgithubへの初プルリクです！（何かプルリクの仕方など変でしたら教えてください。。）